### PR TITLE
refactor: reduze image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,13 @@ WORKDIR /usr/src/dzil
 
 # REF: http://dzil.org/
 COPY cpanfile .
-RUN cpanm Dist::Zilla \
-    && cpanm --installdeps .
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y && \
+    apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+RUN cpanm --notest Dist::Zilla && rm -rf $HOME/.cpanm && rm -rf /tmp/*
+RUN cpanm --installdeps --notest . && rm -rf $HOME/.cpanm && rm -rf /tmp/*
 
 # This is our staging work directory
 WORKDIR /tmp


### PR DESCRIPTION
# Description

Applying upgrades with APT, since it's possible to get fixes between new releases of the base image. Cleaning up after that.

Installing and cleaning the modules install with `cpanm`.

Also added the `--notest` option to avoid testing those modules. This is a tradeoff between faster image generation and stability of the image. Overall, we could rely on results from CPAN Smoker running Debian GNU Linux: http://matrix.cpantesters.org/?dist=Dist-Zilla%206.025;os=linux;reports=1

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
