### PR TITLE
Multiplatform support and build-push clean up

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -
@@ -42,6 +39,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             jonasbn/ebirah:latest
             ghcr.io/jonasbn/ebirah:latest


### PR DESCRIPTION
Added build support for more platforms and removed obsolete step, the Git context is handled by the build-push action itself

REF:

- https://github.com/docker/build-push-action?tab=readme-ov-file#git-context
