### PR TITLE
Add BuildKit check directive to suppress InvalidDefaultArgInFrom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=InvalidDefaultArgInFrom
 
 ARG BASE_IMAGE=perl:5.40.2-slim-bookworm@sha256:ffca6fbf5d40c2dc3dac0fc11640e29feaabef54cf274e3d4cb24204ae62ccc2
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
## Summary

- Adds `# check=skip=InvalidDefaultArgInFrom` directive at the top of the Dockerfile
- Docker BuildKit 26+ lints Dockerfiles and flags `InvalidDefaultArgInFrom` when an `ARG` is referenced in a `FROM` instruction, even when the ARG has a default value — which is the case here with the pinned `BASE_IMAGE`
- Suppressing the check explicitly keeps the intentional pattern (overridable base image with a pinned SHA256 default) without noisy lint warnings

## Test plan

- [ ] Verify `docker build` completes without lint warnings on BuildKit 26+
- [ ] Confirm CI passes (markdownlint, spellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)