### PR TITLE
Add zizmor workflow to statically analyze GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     # Assign pull requests to an assignee
     assignees:
       - "jonasbn"
+    cooldown:
+      default-days: 7
   # Enable version updates for Actions
   - package-ecosystem: "github-actions"
     # Look for `.github/workflows` in the `root` directory
@@ -20,3 +22,5 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ jobs:
   documentation:
     name: Check documentation integrity and spelling
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     
     - name: Check spelling in Markdown files
       uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,8 @@ jobs:
       # Checkout the repository, not required by the Docker build parts, but for the publication of the Docker README
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: ["**"]
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Check workflows and actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Note: `CLAUDE.md` and `.claude/**/*.md` are excluded from spell checking (see `.
 - **publish.yml**: Triggered on push to `master` and version tags (`*.*.*`) — builds multi-platform images (`linux/amd64`, `linux/arm64`) and pushes to DockerHub (`jonasbn/ebirah`) and GHCR (`ghcr.io/jonasbn/ebirah`)
   - GHCR login uses `secrets.GITHUB_TOKEN` (not a PAT); the old `CR_PAT` secret still exists in the repo but is unused
   - Multi-platform builds take ~7–10 minutes to complete
+- **zizmor.yml**: Runs on push to `master` and all PRs — statically analyzes every workflow/action under `.github/` with [zizmor](https://woodruffw.github.io/zizmor/) via `zizmorcore/zizmor-action`, uploading findings to the repo's Code Scanning (Security) tab; does not fail the build on findings (public repo → Advanced Security is free)
 
 ### Debugging CI failures
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Note: `CLAUDE.md` and `.claude/**/*.md` are excluded from spell checking (see `.
 - **publish.yml**: Triggered on push to `master` and version tags (`*.*.*`) — builds multi-platform images (`linux/amd64`, `linux/arm64`) and pushes to DockerHub (`jonasbn/ebirah`) and GHCR (`ghcr.io/jonasbn/ebirah`)
   - GHCR login uses `secrets.GITHUB_TOKEN` (not a PAT); the old `CR_PAT` secret still exists in the repo but is unused
   - Multi-platform builds take ~7–10 minutes to complete
-- **zizmor.yml**: Runs on push to `master` and all PRs — statically analyzes every workflow/action under `.github/` with [zizmor](https://woodruffw.github.io/zizmor/) via `zizmorcore/zizmor-action`, uploading findings to the repo's Code Scanning (Security) tab; does not fail the build on findings (public repo → Advanced Security is free)
+- **zizmor.yml**: Runs on push to `master` and PRs — statically analyzes every workflow/action under `.github/` with [zizmor](https://woodruffw.github.io/zizmor/) via `zizmorcore/zizmor-action`, uploading findings to the repo's Code Scanning (Security) tab (note: forked PRs may not be able to upload due to `security-events: write` restrictions); does not fail the build on findings (public repo → Advanced Security is free)
 
 ### Debugging CI failures
 ```bash


### PR DESCRIPTION
## Summary
- Add `.github/workflows/zizmor.yml`, which runs [zizmor](https://woodruffw.github.io/zizmor/) via the official `zizmorcore/zizmor-action` (pinned by SHA) on push to `master` and on every PR, scanning all workflows and actions and uploading findings to the repo's Security → Code Scanning tab
- Fix all findings zizmor raised against the existing configuration:
  - `persist-credentials: false` on every `actions/checkout` step (artipacked)
  - explicit minimal `permissions: contents: read` on the `ci.yml` documentation job (excessive-permissions)
  - 7-day cooldown on both `dependabot.yml` update blocks (dependabot-cooldown)
- Document the new workflow in `CLAUDE.md`

## Test plan
- [x] `zizmor .` run locally (offline and online, with `--min-severity=informational --min-confidence=low`) — no findings remain
- [x] New workflow YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI passes on this PR (ci.yml + new zizmor.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)