### PR TITLE
Fix zizmor pedantic-persona findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,18 @@ name: Continuous Integration (CI)
 
 on: [push, pull_request]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   documentation:
     name: Check documentation integrity and spelling
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # checkout the repository
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ name: Publish to DockerHub and GitHub
 on:
   push:
     branches:
-    - master
+      - master
     tags:
       - "*.*.*"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,18 +4,25 @@ name: Publish to DockerHub and GitHub
 
 on:
   push:
-    branches: 
+    branches:
     - master
     tags:
       - "*.*.*"
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
+    name: Build and publish Docker images
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
-      packages: write
+      contents: read # checkout the repository
+      packages: write # push images to GHCR
 
     steps:
       - name: Docker meta

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,14 +7,18 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     name: Check workflows and actions with zizmor
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      contents: read
-      actions: read
+      security-events: write # upload SARIF findings to the Code Scanning tab
+      contents: read # checkout the repository
+      actions: read # required by zizmor-action to resolve reusable workflows
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary
- Follow-up to #188. Running `zizmor . --persona=pedantic --min-severity=informational --min-confidence=low` surfaced 8 lower-tier findings (code-smell/style level, not real vulnerabilities) across `ci.yml`, `publish.yml`, and `zizmor.yml`
- Adds workflow-level `permissions: {}` defaults, `concurrency` groups, a job `name:`, and explanatory comments on permission grants to resolve all of them
- `publish.yml` uses `cancel-in-progress: false` since canceling a `docker push` mid-flight could leave a partially-pushed manifest; `ci.yml` and `zizmor.yml` use `cancel-in-progress: true` since those jobs are cheap to re-run

## Test plan
- [x] `zizmor . --persona=pedantic --min-severity=informational --min-confidence=low` — no findings remain (was 8)
- [x] `zizmor .` (default regular persona) — still no findings
- [x] YAML validated for all three workflow files
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)