### PR TITLE
Scope DockerHub secrets to dedicated environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: dockerhub-release
 
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Note: `CLAUDE.md` and `.claude/**/*.md` are excluded from spell checking (see `.
 - **publish.yml**: Triggered on push to `master` and version tags (`*.*.*`) — builds multi-platform images (`linux/amd64`, `linux/arm64`) and pushes to DockerHub (`jonasbn/ebirah`) and GHCR (`ghcr.io/jonasbn/ebirah`)
   - GHCR login uses `secrets.GITHUB_TOKEN` (not a PAT); the old `CR_PAT` secret still exists in the repo but is unused
   - Multi-platform builds take ~7–10 minutes to complete
+  - The `publish` job runs under the `dockerhub-release` environment; `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` are environment secrets scoped to it, not repository-level secrets
 - **zizmor.yml**: Runs on push to `master` and PRs — statically analyzes every workflow/action under `.github/` with [zizmor](https://woodruffw.github.io/zizmor/) via `zizmorcore/zizmor-action`, uploading findings to the repo's Code Scanning (Security) tab (note: forked PRs may not be able to upload due to `security-events: write` restrictions); does not fail the build on findings (public repo → Advanced Security is free)
 
 ### Debugging CI failures


### PR DESCRIPTION
## Summary
- `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` were plain repository-level secrets, readable by any workflow run in this repo with no protection rules gating access
- Mirrors the same fix already applied in `jonasbn/docker-cheatset`: a `dockerhub-release` environment has been created and the two secrets moved into it (done outside this PR, via the GitHub UI)
- This PR adds `environment: dockerhub-release` to the `publish` job in `publish.yml` so it resolves the secrets from that environment
- Documents the change in `CLAUDE.md`

## Follow-up (not in this PR)
Once this merges and a release confirms the environment-scoped secrets resolve correctly, the old repository-level `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets should be deleted — otherwise they remain globally readable by any other workflow that doesn't declare this environment, which defeats the purpose of scoping them.

## Test plan
- [x] YAML validated
- [x] `zizmor .` — no findings
- [ ] CI passes on this PR
- [ ] Next tag/push to `master` successfully logs in to DockerHub using the environment-scoped secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)