### PR TITLE
Bump base image to perl:5.44.0-slim-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE}
 
 # We point to the original repository for the image
 LABEL org.opencontainers.image.source="https://github.com/jonasbn/ebirah"
-LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.44.0-trixie"
+LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.44.0-slim-trixie"
 LABEL org.opencontainers.image.url="https://github.com/jonasbn/ebirah"
 LABEL org.opencontainers.image.title="ebirah"
 LABEL org.opencontainers.image.description="Experimental Docker image for Dist::Zilla"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # check=skip=InvalidDefaultArgInFrom
 
-ARG BASE_IMAGE=perl:5.40.2-slim-bookworm@sha256:ffca6fbf5d40c2dc3dac0fc11640e29feaabef54cf274e3d4cb24204ae62ccc2
+ARG BASE_IMAGE=perl:5.44.0-slim-trixie@sha256:c9aac2fcb8612b25b818df998413423eecf15d8d5175c98d1c10a069ac7e7f8f
 FROM ${BASE_IMAGE}
 
 # REF: https://docs.docker.com/engine/reference/builder/
@@ -9,13 +9,13 @@ FROM ${BASE_IMAGE}
 
 # We point to the original repository for the image
 LABEL org.opencontainers.image.source="https://github.com/jonasbn/ebirah"
-LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.40.2-bookworm"
+LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.44.0-trixie"
 LABEL org.opencontainers.image.url="https://github.com/jonasbn/ebirah"
 LABEL org.opencontainers.image.title="ebirah"
 LABEL org.opencontainers.image.description="Experimental Docker image for Dist::Zilla"
 
 ENV DEBIAN_FRONTEND=noninteractive RUNNER_GROUP=distzilla RUNNER_USER=runner
-RUN apt-get update && apt-get upgrade -y && apt-get install build-essential -y && apt-get autoremove -y && \
+RUN apt-get update && apt-get upgrade -y && apt-get install build-essential adduser -y && apt-get autoremove -y && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/* && addgroup "$RUNNER_GROUP" && \
     adduser --ingroup "$RUNNER_GROUP" --home /home/runner --shell /bin/bash \
     --disabled-password --gecos '' runner


### PR DESCRIPTION
## Summary
- Bumps the pinned base image from `perl:5.40.2-slim-bookworm` to `perl:5.44.0-slim-trixie`, using the correct multi-arch manifest-list digest (`sha256:c9aac2fcb8612b25b818df998413423eecf15d8d5175c98d1c10a069ac7e7f8f`, covers `linux/amd64` and `linux/arm64` as built by `publish.yml`)
- Adds `adduser` to the `apt-get install` step — Debian trixie-slim no longer ships the `adduser` package by default (bookworm-slim did), so `addgroup`/`adduser` fail with `exit 127` without it
- Updates the `org.opencontainers.image.base.name` label to match

## Test plan
- [x] Local `docker build` against the new pinned digest — fails without the `adduser` fix, succeeds with it
- [x] `docker run --rm <image> version` → `dzil (Dist::Zilla::App) version 6.037`
- [x] `docker run --rm <image> help` lists all expected `dzil` commands
- [x] Confirmed non-root `runner` user (uid/gid 1000, group `distzilla`) is created correctly
- [x] Confirmed all `cpanfile` dependencies (Dist::Zilla + 33 plugins) build cleanly under Perl 5.44.0 / gcc 14
- [x] Image size drops from ~608MB to ~563MB
- [ ] CI (markdownlint, spellcheck, zizmor) — unaffected by this change but should pass
- [ ] Multi-platform `publish.yml` build on merge to `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)